### PR TITLE
Fix group mappings for removed Groups

### DIFF
--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -491,6 +491,23 @@ SilverStripe\LDAP\Services\LDAPService:
   allow_password_change: true
 ```
 
+### Allow SilverStripe attributes to be reset (removed) by AD
+
+By default if attributes are present, and then missing in subsequent requests, they are ignored (non-descructive) by 
+this module. This can cause attributes to perist when they've been deliberately removed (attribute is no longer present)
+in the LDAP source data. 
+
+If you wish a full two way sync to occur, then set the attribute on `LDAPService` for `reset_missing_attributes` to 
+enable a full sync. 
+
+*Note*: This will mean syncs are desctructive, and data or attributes will be reset if missing from the master LDAP source
+data. 
+
+```yaml
+SilverStripe\LDAP\Services\LDAPService:
+  reset_missing_attributes: true 
+```
+
 This will allow users to change their AD password via the regular CMS "forgot password" forms, etc.
 
 ### Writing LDAP data from SilverStripe

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -491,24 +491,24 @@ SilverStripe\LDAP\Services\LDAPService:
   allow_password_change: true
 ```
 
+This will allow users to change their AD password via the regular CMS "forgot password" forms, etc.
+
 ### Allow SilverStripe attributes to be reset (removed) by AD
 
-By default if attributes are present, and then missing in subsequent requests, they are ignored (non-descructive) by 
-this module. This can cause attributes to perist when they've been deliberately removed (attribute is no longer present)
+By default if attributes are present, and then missing in subsequent requests, they are ignored (non-destructive) by 
+this module. This can cause attributes to persist when they've been deliberately removed (attribute is no longer present)
 in the LDAP source data. 
 
 If you wish a full two way sync to occur, then set the attribute on `LDAPService` for `reset_missing_attributes` to 
 enable a full sync. 
 
-*Note*: This will mean syncs are desctructive, and data or attributes will be reset if missing from the master LDAP source
+*Note*: This will mean syncs are destructive, and data or attributes will be reset if missing from the master LDAP source
 data. 
 
 ```yaml
 SilverStripe\LDAP\Services\LDAPService:
   reset_missing_attributes: true 
 ```
-
-This will allow users to change their AD password via the regular CMS "forgot password" forms, etc.
 
 ### Writing LDAP data from SilverStripe
 

--- a/src/Extensions/LDAPMemberExtension.php
+++ b/src/Extensions/LDAPMemberExtension.php
@@ -248,6 +248,7 @@ class LDAPMemberExtension extends DataExtension
         }
 
         $service->deleteLDAPMember($this->owner);
+
     }
 
     /**

--- a/src/Services/LDAPService.php
+++ b/src/Services/LDAPService.php
@@ -655,6 +655,12 @@ class LDAPService implements Flushable
         $existingObj = $member->getComponent($fieldName);
         if ($existingObj && $existingObj->exists()) {
             $file = $existingObj;
+
+            // If the file hashes match, and the file already exists, we don't need to update anything.
+            $hash = $existingObj->File->getHash();
+            if (hash_equals($hash, sha1($data[$attributeName]))) {
+                return;
+            }
         } else {
             $file = new Image();
         }
@@ -664,7 +670,8 @@ class LDAPService implements Flushable
         $filename = sprintf('thumbnailphoto-%s.jpg', $data['objectguid']);
         $filePath = File::join_paths($thumbnailFolder->getFilename(), $filename);
         $fileCfg = [
-            'conflict' => AssetStore::CONFLICT_USE_EXISTING,
+            // if there's a filename conflict we've got new content so overwrite it.
+            'conflict' => AssetStore::CONFLICT_OVERWRITE,
             'visibility' => AssetStore::VISIBILITY_PUBLIC
         ];
 

--- a/tests/php/Model/LDAPFakeGateway.php
+++ b/tests/php/Model/LDAPFakeGateway.php
@@ -45,7 +45,7 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
                 'samaccountname' => 'joe'
             ],
             '456' => [
-                'distinguishedname' => 'CN=Appleseed,DC=playpen,DCx=local',
+                'distinguishedname' => 'CN=Appleseed,DC=playpen,DC=local',
                 'objectguid' => '456',
                 'cn' => 'jappleseed',
                 'useraccountcontrol' => '1',
@@ -53,11 +53,32 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
                 'sn' => 'Appleseed',
                 'mail' => 'john@appleseed.com',
                 'password' => 'mockPassword1',
-                'canonicalName'=>'mockCanonicalName2',
+                'canonicalName' => 'mockCanonicalName2',
                 'userprincipalname' => 'john@appleseed.com',
                 'samaccountname' => 'john',
                 'thumbnailphoto' => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
                 'displayname' => 'Johnny Appleseed'
+            ],
+            '789' => [
+                'distinguishedname' => 'CN=Appleseed,DC=playpen,DC=local',
+                'objectguid' => '456',
+                'cn' => 'jappleseed',
+                'useraccountcontrol' => '1',
+                'givenname' => 'Johnny',
+                'sn' => 'Appleseed',
+                'mail' => 'john@appleseed.com',
+                'password' => 'mockPassword1',
+                'canonicalName' => 'mockCanonicalName2',
+                'userprincipalname' => 'john@appleseed.com',
+                'samaccountname' => 'john',
+                'thumbnailphoto' => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
+                'displayname' => 'Johnny Appleseed',
+                'memberof' => [
+                    'CN=Group1,CN=Users,DC=playpen,DC=local',
+                    'CN=Group2,CN=Users,DC=playpen,DC=local',
+                    'CN=Group3,CN=Users,DC=playpen,DC=local',
+                    'CN=Group4,CN=Users,DC=playpen,DC=local',
+                ]
             ]
         ]
     ];
@@ -93,8 +114,19 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
         }
     }
 
+    /**
+     * Return nested groups for a DN. Not currently implemented.
+     *
+     * @param string $dn
+     * @param null $baseDn
+     * @param int $scope
+     * @param array $attributes
+     *
+     * @return array
+     */
     public function getNestedGroups($dn, $baseDn = null, $scope = Ldap::SEARCH_SCOPE_SUB, $attributes = [])
     {
+        return [];
     }
 
     public function getGroupByGUID($guid, $baseDn = null, $scope = Ldap::SEARCH_SCOPE_SUB, $attributes = [])

--- a/tests/php/Model/LDAPFakeGateway.php
+++ b/tests/php/Model/LDAPFakeGateway.php
@@ -11,7 +11,8 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
 {
     public function __construct()
     {
-        // do nothing
+        // thumbnail images are raw png
+        self::$data['users']['456']['thumbnailphoto'] = base64_decode(self::$data['users']['456']['thumbnailphoto']);
     }
 
     private static $data = [
@@ -42,6 +43,21 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
                 'canonicalName'=>'mockCanonicalName',
                 'userprincipalname' => 'joe@bloggs.com',
                 'samaccountname' => 'joe'
+            ],
+            '456' => [
+                'distinguishedname' => 'CN=Appleseed,DC=playpen,DCx=local',
+                'objectguid' => '456',
+                'cn' => 'jappleseed',
+                'useraccountcontrol' => '1',
+                'givenname' => 'Johnny',
+                'sn' => 'Appleseed',
+                'mail' => 'john@appleseed.com',
+                'password' => 'mockPassword1',
+                'canonicalName'=>'mockCanonicalName2',
+                'userprincipalname' => 'john@appleseed.com',
+                'samaccountname' => 'john',
+                'thumbnailphoto' => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
+                'displayname' => 'Johnny Appleseed'
             ]
         ]
     ];

--- a/tests/php/Model/LDAPFakeGateway.php
+++ b/tests/php/Model/LDAPFakeGateway.php
@@ -11,7 +11,8 @@ class LDAPFakeGateway extends LDAPGateway implements TestOnly
 {
     public function __construct()
     {
-        // thumbnail images are raw png
+        // thumbnail images are raw JPEG/JFIF files, but that's not important
+        // for this test, as long as the binary content are the same
         self::$data['users']['456']['thumbnailphoto'] = base64_decode(self::$data['users']['456']['thumbnailphoto']);
     }
 

--- a/tests/php/Model/LDAPFakeMember.php
+++ b/tests/php/Model/LDAPFakeMember.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SilverStripe\LDAP\Tests\Model;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Member;
+use SilverStripe\Assets\Image;
+
+class LDAPFakeMember extends Member implements TestOnly
+{
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'ProfileImage' => Image::class
+    ];
+
+    /**
+     * We don't actually want/need to change anything
+     *
+     * @return int|void
+     */
+    public function write(){
+        // Noop
+    }
+}

--- a/tests/php/Services/LDAPServiceTest.php
+++ b/tests/php/Services/LDAPServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\LDAP\Tests\Services;
 
+use SilverStripe\Assets\Image;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
@@ -10,12 +11,19 @@ use SilverStripe\LDAP\Extensions\LDAPMemberExtension;
 use SilverStripe\LDAP\Model\LDAPGateway;
 use SilverStripe\LDAP\Services\LDAPService;
 use SilverStripe\LDAP\Tests\Model\LDAPFakeGateway;
+use SilverStripe\LDAP\Tests\Model\LDAPFakeMember;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
+use Silverstripe\Assets\Dev\TestAssetStore;
 
 class LDAPServiceTest extends SapphireTest
 {
     protected $usesDatabase = true;
+
+    /**
+     * @var LDAPService
+     */
+    private $service;
 
     protected function setUp()
     {
@@ -94,5 +102,77 @@ class LDAPServiceTest extends SapphireTest
         $this->assertEquals('Joe', $member->FirstName, 'FirstName updated from LDAP');
         $this->assertEquals('Bloggs', $member->Surname, 'Surname updated from LDAP');
         $this->assertEquals('joe@bloggs.com', $member->Email, 'Email updated from LDAP');
+    }
+
+    /**
+     * If the LDAPService setting reset_missing_attributes is true, reset fields if the attribute isn't present
+     * in the response information.
+     */
+    public function testUpdateMemberResetAttributesFromLDAP()
+    {
+        Config::modify()->set(
+            Member::class,
+            'ldap_field_mappings',
+            [
+                'givenname' => 'FirstName',
+                'sn' => 'Surname',
+                'mail' => 'Email',
+                'specialattribute' => 'specialattribute'
+            ]
+        );
+
+        Config::modify()->set(LDAPService::class,'reset_missing_attributes', true);
+
+        $member = new Member();
+        $member->GUID = '123';
+        $member->specialattribute = "I should be removed because LDAP said so";
+
+        $this->service->updateMemberFromLDAP($member);
+
+        $this->assertTrue($member->ID > 0, 'updateMemberFromLDAP writes the member');
+        $this->assertEquals('123', $member->GUID, 'GUID remains the same');
+        $this->assertEquals('Joe', $member->FirstName, 'FirstName updated from LDAP');
+        $this->assertEquals('Bloggs', $member->Surname, 'Surname updated from LDAP');
+        $this->assertEquals('joe@bloggs.com', $member->Email, 'Email updated from LDAP');
+        $this->assertNull($member->specialattribute);
+    }
+
+    /**
+     * If the LDAPService setting reset_missing_attributes is true, delete the thumbnail (special case)
+     * if it's not present in the response information.
+     */
+    public function testUpdateMemberResetThumbnailFromLDAP()
+    {
+        Config::modify()->set(
+            Member::class,
+            'ldap_field_mappings',
+            [
+                'givenname' => 'FirstName',
+                'sn' => 'Surname',
+                'mail' => 'Email',
+                'thumbnailphoto' => 'ProfileImage'
+            ]
+        );
+
+        Config::modify()->set(LDAPService::class,'reset_missing_attributes', true);
+
+        // Create a test 'image' for this member.
+        /** @var File $file */
+        TestAssetStore::activate('FileTest');
+        $file = new Image();
+        $file->setFromString(str_repeat('x', 1000000), "test.jpg");
+
+        $member = new LDAPFakeMember();
+        $member->GUID = '123';
+        $member->setComponent("ProfileImage", $file);
+
+        // make sure our Profile image is there.
+        $this->assertNotNull($member->ProfileImage);
+        $this->assertTrue($member->ProfileImage->exists());
+
+        $this->service->updateMemberFromLDAP($member);
+
+        // ensure the profile image was deleted, as it wasn't present in the attribute response from TestLDAP service
+        $this->assertFalse($member->ProfileImage->exists());
     }
 }

--- a/tests/php/Services/LDAPServiceTest.yml
+++ b/tests/php/Services/LDAPServiceTest.yml
@@ -1,0 +1,38 @@
+SilverStripe\Security\Group:
+  group1:
+   Title: "Group 1"
+   GUID: "d339637c-d0c1-11e8-80b6-7831c1cc1572"
+   DN: 'CN=Group1,CN=Users,DC=playpen,DC=local'
+  group2:
+   Title: "Group 2"
+   GUID: "df05eb94-d0c1-11e8-80b6-7831c1cc1572"
+   DN: 'CN=Group2,CN=Users,DC=playpen,DC=local'
+  group3:
+   GUID: "e80dd03a-d0c1-11e8-80b6-7831c1cc1572"
+   Title: "Group 3"
+   DN: 'CN=Group3,CN=Users,DC=playpen,DC=local'
+  group4:
+   GUID: "ee36f90a-d0c1-11e8-80b6-7831c1cc1572"
+   Title: "Group 4"
+   DN: 'CN=Group4,CN=Users,DC=playpen,DC=local'
+  group5:
+   GUID: "f4e9b9ae-d0c1-11e8-80b6-7831c1cc1572"
+   Title: "Group 5"
+   DN: 'CN=Group5,CN=Users,DC=playpen,DC=local'
+
+SilverStripe\LDAP\Model\LDAPGroupMapping:
+  group1:
+    Group: =>SilverStripe\Security\Group.group1
+    DN: 'CN=Group1,CN=Users,DC=playpen,DC=local'
+  group2:
+    Group: =>SilverStripe\Security\Group.group2
+    DN: 'CN=Group2,CN=Users,DC=playpen,DC=local'
+  group3:
+    Group: =>SilverStripe\Security\Group.group3
+    DN: 'CN=Group3,CN=Users,DC=playpen,DC=local'
+  group4:
+    Group: =>SilverStripe\Security\Group.group4
+    DN: 'CN=Group4,CN=Users,DC=playpen,DC=local'
+  group5:
+    Group: =>SilverStripe\Security\Group.group5
+    DN: 'CN=Group5,CN=Users,DC=playpen,DC=local'


### PR DESCRIPTION
Resolve removed LDAP group mappings

Members which belonged to LDAP mapped groups weren't being removed from
these associations if the LDAP data no longer contained the mappings.

This meant if a group association was removed from LDAP the member was
never updated.

This also must Account for situations where there's no more mappings
or no mappings are given.